### PR TITLE
Add handling for signed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ No requirements.
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `sentinelone_filename` | *(empty)* | Package file to install |
-| `sentinelone_token` | *(empty)* | Group/Site token |
-| `sentinelone_gpgkey` | *(empty)* | GPG signing key to import |
+| `sentinelone_client_filename` | *(empty)* | Package file to install |
+| `sentinelone_client_token` | *(empty)* | Group/Site token |
+| `sentinelone_client_gpgkey` | *(empty)* | GPG signing key to import |
 
 ## Dependencies
 
@@ -24,8 +24,8 @@ No dependencies.
 - hosts: clients
   roles:
     - role: stdevel.sentinelone_client
-      sentinelone_filename: SentinelAgent_linux_v21_10_3_3.rpm
-      sentinelone_token: trustno1
+      sentinelone_client_filename: SentinelAgent_linux_v21_10_3_3.rpm
+      sentinelone_client_token: trustno1
 ```
 
 Repository installation:
@@ -34,8 +34,8 @@ Repository installation:
 - hosts: clients
   roles:
     - role: stdevel.sentinelone_client
-      sentinelone_filename: https://simone.giertz.dev/SentinelAgent_linux_v13_37.deb
-      sentinelone_token: trustno1
+      sentinelone_client_filename: https://simone.giertz.dev/SentinelAgent_linux_v13_37.deb
+      sentinelone_client_token: trustno1
 ```
 
 ## Development / testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-sentinelone_token: ''
-sentinelone_gpgkey: ''
+sentinelone_client_token: ''
+sentinelone_client_gpgkey: ''

--- a/molecule/default/README.md
+++ b/molecule/default/README.md
@@ -5,7 +5,7 @@ In order to test the role you'll need Ansible, Molecule and a supported provider
 If you also want to test registration, add the following line to [`converge.yml`](converge.yml):
 
 ```yml
-sentinelone_token: "..."
+sentinelone_client_token: "..."
 ```
 
 Copy the SentinelONE installation files (`sentinelone_latest.deb`, `sentinelone_latest.rpm`) into this directory and run `molecule`:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,6 +12,11 @@
         file_sentinelone: sentinelone_latest.rpm
       when: ansible_os_family == 'RedHat'
 
+    - name: Set SentinelONE client installation file (SUSE)
+      ansible.builtin.set_fact:
+        file_sentinelone: sentinelone_latest.rpm
+      when: ansible_os_family == 'Suse'
+
   roles:
     - role: stdevel.sentinelone_client
       sentinelone_filename: "{{ file_sentinelone }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,6 @@
 
   roles:
     - role: stdevel.sentinelone_client
-      sentinelone_filename: "{{ file_sentinelone }}"
-      # sentinelone_token: '...'
-      # sentinelone_gpgkey: '...'
+      sentinelone_client_filename: "{{ file_sentinelone }}"
+      # sentinelone_client_token: '...'
+      # sentinelone_client_gpgkey: '...'

--- a/tasks/digest.yml
+++ b/tasks/digest.yml
@@ -1,11 +1,11 @@
 ---
 - name: Gather RPM package version
-  ansible.builtin.command: "rpm -qp --queryformat '%{VERSION}' /tmp/{{ sentinelone_filename | basename }}"
-  register: sentinelone_rpm_version
+  ansible.builtin.command: "rpm -qp --queryformat '%{VERSION}' /tmp/{{ sentinelone_client_filename | basename }}"
+  register: sentinelone_client_rpm_version
   changed_when: false
 
 - name: Set nodigest flag, if required
   ansible.builtin.set_fact:
-    sentinelone_digest: '--nodigest'
+    sentinelone_client_digest: '--nodigest'
   when:
-    - "sentinelone_rpm_version.stdout is version('23.3.2.12', '<')"
+    - "sentinelone_client_rpm_version.stdout is version('23.3.2.12', '<')"

--- a/tasks/digest.yml
+++ b/tasks/digest.yml
@@ -1,0 +1,11 @@
+---
+- name: Gather RPM package version
+  ansible.builtin.command: "rpm -qp --queryformat '%{VERSION}' /tmp/{{ sentinelone_filename | basename }}"
+  register: sentinelone_rpm_version
+  changed_when: false
+
+- name: Set nodigest flag, if required
+  ansible.builtin.set_fact:
+    sentinelone_digest: '--nodigest'
+  when:
+    - "sentinelone_rpm_version.stdout is version('23.3.2.12', '<')"

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -1,12 +1,12 @@
 ---
 - name: Import GPG key
   ansible.builtin.apt_key:
-    url: "{{ sentinelone_gpgkey }}"
+    url: "{{ sentinelone_client_gpgkey }}"
   become: true
-  when: sentinelone_gpgkey
+  when: sentinelone_client_gpgkey
 
 - name: Install package
   ansible.builtin.apt:
-    deb: "/tmp/{{ sentinelone_filename | basename }}"
+    deb: "/tmp/{{ sentinelone_client_filename | basename }}"
     update_cache: true
   become: true

--- a/tasks/install_redhat.yml
+++ b/tasks/install_redhat.yml
@@ -1,15 +1,15 @@
 ---
 - name: Import GPG key
   ansible.builtin.rpm_key:
-    key: "{{ sentinelone_gpgkey }}"
+    key: "{{ sentinelone_client_gpgkey }}"
   become: true
-  when: sentinelone_gpgkey
+  when: sentinelone_client_gpgkey
 
 - name: Include digest tasks
   ansible.builtin.include_tasks: digest.yml
 
 - name: Install package (digest)
-  ansible.builtin.command: "rpm -ivh --nodigest /tmp/{{ sentinelone_filename | basename }}"
+  ansible.builtin.command: "rpm -ivh --nodigest /tmp/{{ sentinelone_client_filename | basename }}"
   register: rpmout
   changed_when:
     - "'Updating / installing' in rpmout.stdout"
@@ -18,9 +18,9 @@
     - "'is already installed' not in rpmout.stderr"
   ignore_errors: true
   become: true
-  when: sentinelone_digest is defined
+  when: sentinelone_client_digest is defined
 
 - name: Install package
   ansible.builtin.yum:
-    name: "/tmp/{{ sentinelone_filename | basename }}"
+    name: "/tmp/{{ sentinelone_client_filename | basename }}"
   become: true

--- a/tasks/install_redhat.yml
+++ b/tasks/install_redhat.yml
@@ -5,9 +5,10 @@
   become: true
   when: sentinelone_gpgkey
 
-# Yep, we really need to use rpm directly as yum/dnf
-# won't install packages without digests
-- name: Install package
+- name: Include digest tasks
+  ansible.builtin.include_tasks: digest.yml
+
+- name: Install package (digest)
   ansible.builtin.command: "rpm -ivh --nodigest /tmp/{{ sentinelone_filename | basename }}"
   register: rpmout
   changed_when:
@@ -16,4 +17,10 @@
     - rpmout.failed
     - "'is already installed' not in rpmout.stderr"
   ignore_errors: true
+  become: true
+  when: sentinelone_digest is defined
+
+- name: Install package
+  ansible.builtin.yum:
+    name: "/tmp/{{ sentinelone_filename | basename }}"
   become: true

--- a/tasks/install_redhat.yml
+++ b/tasks/install_redhat.yml
@@ -24,3 +24,4 @@
   ansible.builtin.yum:
     name: "/tmp/{{ sentinelone_client_filename | basename }}"
   become: true
+  when: sentinelone_client_digest is not defined

--- a/tasks/install_suse.yml
+++ b/tasks/install_suse.yml
@@ -24,3 +24,4 @@
   community.general.zypper:
     name: "/tmp/{{ sentinelone_client_filename | basename }}"
   become: true
+  when: sentinelone_client_digest is not defined

--- a/tasks/install_suse.yml
+++ b/tasks/install_suse.yml
@@ -5,9 +5,10 @@
   become: true
   when: sentinelone_gpgkey
 
-# Yep, we really need to use rpm directly as zypper
-# won't install packages without digests
-- name: Install package
+- name: Include digest tasks
+  ansible.builtin.include_tasks: digest.yml
+
+- name: Install package (digest)
   ansible.builtin.command: "rpm -ivh --nodigest /tmp/{{ sentinelone_filename | basename }}"
   register: rpmout
   changed_when:
@@ -16,4 +17,10 @@
     - rpmout.failed
     - "'is already installed' not in rpmout.stderr"
   ignore_errors: true
+  become: true
+  when: sentinelone_digest is defined
+
+- name: Install package
+  community.general.zypper:
+    name: "/tmp/{{ sentinelone_filename | basename }}"
   become: true

--- a/tasks/install_suse.yml
+++ b/tasks/install_suse.yml
@@ -1,15 +1,15 @@
 ---
 - name: Import GPG key
   ansible.builtin.rpm_key:
-    key: "{{ sentinelone_gpgkey }}"
+    key: "{{ sentinelone_client_gpgkey }}"
   become: true
-  when: sentinelone_gpgkey
+  when: sentinelone_client_gpgkey
 
 - name: Include digest tasks
   ansible.builtin.include_tasks: digest.yml
 
 - name: Install package (digest)
-  ansible.builtin.command: "rpm -ivh --nodigest /tmp/{{ sentinelone_filename | basename }}"
+  ansible.builtin.command: "rpm -ivh --nodigest /tmp/{{ sentinelone_client_filename | basename }}"
   register: rpmout
   changed_when:
     - "'Updating / installing' in rpmout.stdout"
@@ -18,9 +18,9 @@
     - "'is already installed' not in rpmout.stderr"
   ignore_errors: true
   become: true
-  when: sentinelone_digest is defined
+  when: sentinelone_client_digest is defined
 
 - name: Install package
   community.general.zypper:
-    name: "/tmp/{{ sentinelone_filename | basename }}"
+    name: "/tmp/{{ sentinelone_client_filename | basename }}"
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,33 +16,33 @@
 
 - name: Download installation package
   ansible.builtin.get_url:
-    url: "{{ sentinelone_filename }}"
-    dest: "/tmp/{{ sentinelone_filename | basename }}"
+    url: "{{ sentinelone_client_filename }}"
+    dest: "/tmp/{{ sentinelone_client_filename | basename }}"
     mode: 0644
-  when: "'http' in sentinelone_filename"
+  when: "'http' in sentinelone_client_filename"
 
 - name: Copy installation package
   ansible.builtin.copy:
-    src: "{{ sentinelone_filename }}"
-    dest: "/tmp/{{ sentinelone_filename | basename }}"
+    src: "{{ sentinelone_client_filename }}"
+    dest: "/tmp/{{ sentinelone_client_filename | basename }}"
     mode: '0644'
-  when: "'http' not in sentinelone_filename"
+  when: "'http' not in sentinelone_client_filename"
 
 - name: Include installation tasks
   ansible.builtin.include_tasks: "install_{{ ansible_os_family | regex_replace(' ', '_') | lower }}.yml"
 
 - name: Remove installation package
   ansible.builtin.file:
-    path: "/tmp/{{ sentinelone_filename | basename }}"
+    path: "/tmp/{{ sentinelone_client_filename | basename }}"
     state: absent
 
 - name: Set Group/Site token
-  ansible.builtin.command: "/opt/sentinelone/bin/sentinelctl management token set {{ sentinelone_token }}"
+  ansible.builtin.command: "/opt/sentinelone/bin/sentinelctl management token set {{ sentinelone_client_token }}"
   args:
     creates: /opt/sentinelone/.INITIALIZATION_COMPLETE
   become: true
   notify: Create initialization file
-  when: sentinelone_token is defined and sentinelone_token != ''
+  when: sentinelone_client_token is defined and sentinelone_client_token != ''
 
 - name: Start agent
   ansible.builtin.command: /opt/sentinelone/bin/sentinelctl control start


### PR DESCRIPTION
Packages are signed since version 23.3.2.12 - see also issue #6.

This PR adds handling for this. So, the `--nodigest` parameter is only used for older versions.

**Breaking change**:
It also uses proper variable name prefixes (`sentinelone_` -> `sentinelone_client_`) as suggessted by ´ansible-lint`.